### PR TITLE
Explicitly specify not to byte-compile

### DIFF
--- a/kanagawa-theme.el
+++ b/kanagawa-theme.el
@@ -592,4 +592,9 @@
                    (file-name-directory load-file-name))))
 
 (provide-theme 'kanagawa)
+
+;; Local Variables:
+;; no-byte-compile: t
+;; End:
+
 ;;; kanagawa-theme.el ends here


### PR DESCRIPTION
This PR prevents kanagawa-theme.el from being byte-compiled as `kanagawa-theme-dark-palette` is determined at runtime.