### PR TITLE
Fix: Dashboard icons and font lock builtin for better readability

### DIFF
--- a/kanagawa-themes.el
+++ b/kanagawa-themes.el
@@ -905,7 +905,7 @@ names to which it refers are bound."
                                             :background ,bright-yellow :slant italic :weight bold :height 138))
 ;;;;;;; emacs-dashboard
       (dashboard-heading (:foreground ,syn-punct :weight bold))
-      (dashboard-items-face (:foreground ,fg))
+      ;;(dashboard-items-face (:foreground ,fg))
       (dashboard-banner-logo-title (:weight bold :height 200))
       (dashboard-no-items-face (:foreground ,bg-p1))
 ;;;;;;; popup

--- a/kanagawa-themes.el
+++ b/kanagawa-themes.el
@@ -504,7 +504,7 @@ names to which it refers are bound."
       (window-divider (:foreground ,bg-m1))
       (vertical-border (:foreground ,bg-m1))
 ;;;;;;; font lock
-      (font-lock-builtin-face (:foreground ,fg))
+      (font-lock-builtin-face (:foreground ,syn-special-2))
       (font-lock-comment-face (:foreground ,syn-comment
                                            :slant ,(if kanagawa-themes-comment-italic 'italic 'normal)))
       (font-lock-comment-delimiter-face (:foreground ,syn-comment))


### PR DESCRIPTION

### Changes

* **Dashboard Icons:** Fixed an issue where icons appeared too small and were overriding native icon colors with text font colors.
* **Built-in Face Readability:** Changed the `font-lock-builtin-face` foreground color to red (matching the tree-sitter built-in variable) to enhance legibility.

<img width="509" height="175" alt="icons" src="https://github.com/user-attachments/assets/55bb092b-2a8f-495f-8179-b6c989b34679" />

If you don't like the red color, feel free to modify it to use the yellow tone (`syn-identifier`) instead.

<img width="622" height="491" alt="face-font" src="https://github.com/user-attachments/assets/637b524b-bf98-4a0c-a94d-16f3012cd514" />